### PR TITLE
[Fix] 실시간 채팅시 프로필 이미지 안 보이는 현상 수정

### DIFF
--- a/src/main/java/DevHeaven/keyword/domain/chat/controller/StompChatController.java
+++ b/src/main/java/DevHeaven/keyword/domain/chat/controller/StompChatController.java
@@ -3,6 +3,8 @@ package DevHeaven.keyword.domain.chat.controller;
 import DevHeaven.keyword.domain.chat.dto.request.ChatRequest;
 import DevHeaven.keyword.domain.chat.entity.Chat;
 import DevHeaven.keyword.domain.chat.service.ChatService;
+import DevHeaven.keyword.domain.member.entity.Member;
+import DevHeaven.keyword.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -15,6 +17,7 @@ public class StompChatController {
     //특정 broker로 메세지 전달
     private final SimpMessagingTemplate template;
     private final ChatService chatService;
+    private final MemberRepository memberRepository;
 
     //client가 SEND 할 수 있는 경로
     //StompWebSocketConfig에서 설정한 applicationDestinationPrefixes와 @MessageMapping 경로가 병합됨
@@ -24,6 +27,11 @@ public class StompChatController {
 
         //db에 메세지 저장
         chatService.createChat(message);
+
+        //회원 조회후 프로필 사진 재설정해서 전송
+        Member member = memberRepository.findById(message.getSenderId()).get();
+        message.setImageUrl(member.getProfileImageFileName());
+        
         //구독하고 있는 클라이언트에 메세지 전송
         template.convertAndSend("/sub/chats/room/" + message.getRoomId(), message);
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
의심가는 부분 함 수정해봤습니다
pub에서 imageUrl을 받지만 그냥 senderId로 member조회해서 구독하는 클라이언트들에 다시 보내주는 걸로 ,,,

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 
